### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Directory listing
         run: ls -lh dist/dm-tree*.tar.gz
         shell: bash
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'created') }}
         with:
           name: dm-tree-${{ github.workflow }}-${{ github.run_number }}
@@ -75,7 +75,7 @@ jobs:
         run: ls -lh wheelhouse/dm_tree*.whl
         shell: bash
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'created') }}
         with:
           name: dm-tree-${{ github.workflow }}-${{ github.run_number }}
@@ -118,7 +118,7 @@ jobs:
         run: ls -lh wheelhouse/dm_tree*.whl
         shell: bash
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'created') }}
         with:
           name: dm-tree-${{ github.workflow }}-${{ github.run_number }}
@@ -175,7 +175,7 @@ jobs:
         run: ls -lh wheelhouse/dm_tree*.whl
         shell: bash
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'created') }}
         with:
           name: dm-tree-${{ github.workflow }}-${{ github.run_number }}


### PR DESCRIPTION
v2 version was deprecated:
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Resolves #121 